### PR TITLE
Sortable with scroll option broken with Prototype 1.7

### DIFF
--- a/src/dragdrop.js
+++ b/src/dragdrop.js
@@ -372,7 +372,7 @@ var Draggable = Class.create({
       if (this.options.scroll == window) {
         with(this._getWindowScroll(this.options.scroll)) { p = [ left, top, left+width, top+height ]; }
       } else {
-        p = Position.page(this.options.scroll);
+        p = Position.page(this.options.scroll).toArray();
         p[0] += this.options.scroll.scrollLeft + Position.deltaX;
         p[1] += this.options.scroll.scrollTop + Position.deltaY;
         p.push(p[0]+this.options.scroll.offsetWidth);


### PR DESCRIPTION
Using a Sortable with the "scroll" option produces an error when coupling with Prototype 1.7 RC2 and trying to drag one of the elements:

p.push is not a function

This is because Prototype's Position.page method no longer returns a plain old array object.  Casting the result of Position.page to an array with toArray() fixes the problem.  It also works for older Prototype versions.
