### PR TITLE
afterUpdateElement on ENTER press

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -129,7 +129,11 @@ Autocompleter.Base = Class.create({
       switch(event.keyCode) {
        case Event.KEY_TAB:
        case Event.KEY_RETURN:
-         this.selectEntry();
+         if (this.options.afterUpdateElement) {
+           this.options.afterUpdateElement(this.element, this.element);
+         } else {
+           this.selectEntry();
+         }
          Event.stop(event);
        case Event.KEY_ESC:
          this.hide();


### PR DESCRIPTION
Currently, if no element is selected in Autocomplete it defaults to the first element if a user presses ENTER. This isn't a good default especially when the users passes in an afterUpdateElement function. The user most likely wants to update the contents of a DOM object after an element is selected with the search results. If no element is selected an the user presses enter its more useful to send the text field content to the user defined afterUpdateElement so that the user can do their own custom search against the field rather than assuming the user wants the first element to be selected.

My changes basically allow a user to define their own search function using afterUpdateElement if no element is selected and ENTER is pressed. If the user doesn't pass in an afterUpdateElement the function behaves as it does now.
