### PR TITLE
AutoCompleter: Better performance using text areas

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -300,7 +300,8 @@ Autocompleter.Base = Class.create({
   onObserverEvent: function() {
     this.changed = false;
     this.tokenBounds = null;
-    if(this.getToken().length>=this.options.minChars) {
+    this.options.regexp ? send=this.options.regexp.match(this.getToken()) : send=true;
+    if(send && this.getToken().length>=this.options.minChars) {
       this.getUpdatedChoices();
     } else {
       this.active = false;


### PR DESCRIPTION
The Autocompleter is designed to send  constantly Ajax requests while you are filling in a field to get the results that fit the input. And so it should work in most cases.

But there is a case where this is not desirable: when you are filling a text area where not every token requires auto-completion. As an example you have the “What’s happening?” box on Twitter. You can enter any text, but if you type a “@” the Autocompleter is activated to look for your friends.

In my application I have a similar box, and I need Autocompleter to run only when a user types a “#” (for tags) or a “:” (for special keywords). If Autocompleter were always running and a lot of users were writing at a time, the server performance would be seriously impaired.

So I have added support for a regexp option. If it exists, Ajax requests are done only if the token matches with the regexp pattern. E.g. regexp: /(#|:)(\w)*/ would activate Ajax requests for tokens that start with ‘#’ or ‘:’.

What do you think?
