### PR TITLE
Resolves an issue with drop targets being incorrectly offset in a scrolled scroll container

### DIFF
--- a/src/dragdrop.js
+++ b/src/dragdrop.js
@@ -355,9 +355,13 @@ var Draggable = Class.create({
   updateDrag: function(event, pointer) {
     if(!this.dragging) this.startDrag(event);
 
+    var dropPoint = (this.options.scroll && this.options.scroll != window) ? 
+      [pointer[0] + this.options.scroll.scrollLeft, pointer[1] + this.options.scroll.scrollTop] :
+      pointer;
+
     if(!this.options.quiet){
       Position.prepare();
-      Droppables.show(pointer, this.element);
+      Droppables.show(dropPoint, this.element);
     }
 
     Draggables.notify('onDrag', this, event);
@@ -373,8 +377,8 @@ var Draggable = Class.create({
         with(this._getWindowScroll(this.options.scroll)) { p = [ left, top, left+width, top+height ]; }
       } else {
         p = Position.page(this.options.scroll).toArray();
-        p[0] += this.options.scroll.scrollLeft + Position.deltaX;
-        p[1] += this.options.scroll.scrollTop + Position.deltaY;
+        p[0] += Position.deltaX;
+        p[1] += Position.deltaY;
         p.push(p[0]+this.options.scroll.offsetWidth);
         p.push(p[1]+this.options.scroll.offsetHeight);
       }


### PR DESCRIPTION
Fixes issue #32.  When dragging draggables within a scroll container, the droppable does not register the scrollLeft or scrollTop of the scrolling container, resulting in a drop offset that is incorrect.  This is particularly noticeable in Sortables when trying to drag down or to the right beyond the scroll limits.

There's still some weird stuff going on when dragging beyond the boundaries of the scroll container, the mouse position relative to the draggable gets altered so that the draggable is no longer below the cursor, but at least the item actually drops into the right place now.  Hopefully someone more competent than I can figure out that bug.
