### PR TITLE
Improved scrolling on Autocompleter when necessary

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -971,5 +971,6 @@ Element.addMethods({
         ? element.offsetTop
         : element.offsetTop - parent.offsetHeight + element.offsetHeight;
     }
+	return element;
   }
 });


### PR DESCRIPTION
Extends Element with .scrollIntoViewIfNecessary() which only scrolls the parent container if the element is not already entirely within view.  This solves two related issues for Autocomplete dropdowns when there are scrollbars.  First, if the user changes direction while scrolling through the choices, the selected LI jumps from the bottom to the top (or vice versa) of the dropdown.  Second, when the autocomplete element is within a containing element with its own scrollbars, using scrollIntoView would scroll the outer scroll bars, moving the LI.selected to the top and obscuring the INPUT element.  This fixes both of those problems.

I can supply a demo page if it would better illustrate.
