### PR TITLE
Fix Divide by Zero bug in translateToPx()

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -148,6 +148,7 @@ Control.Slider = Class.create({
       handleIdx || this.activeHandleIdx || 0);
   },
   translateToPx: function(value) {
+    if ((this.range.end-this.range.start)==0) { return "0px"; }
     return Math.round(
       ((this.trackLength-this.handleLength)/(this.range.end-this.range.start)) *
       (value - this.range.start)) + "px";


### PR DESCRIPTION
Bug that drove me insane hunting down and fixing back in 2010.  Found
the bug is still in the latest version so I applied it to the latest
branch.  If I recall correctly it fails SILENTLY with no errors and
sliders that just don't work. Took days to initially find the problem.

See the insanity it cause me after 3 days of debugging. 
http://blog.hackerceo.org/2010/01/most-arcane-bug-of-them-all-divide-by.html