### PR TITLE
removed document.write part of scriptaculous#require

### DIFF
--- a/src/scriptaculous.js
+++ b/src/scriptaculous.js
@@ -24,16 +24,10 @@
 var Scriptaculous = {
   Version: '1.9.0',
   require: function(libraryName) {
-    try{
-      // inserting via DOM fails in Safari 2.0, so brute force approach
-      document.write('<script type="text/javascript" src="'+libraryName+'"><\/script>');
-    } catch(e) {
-      // for xhtml+xml served content, fall back to DOM methods
-      var script = document.createElement('script');
-      script.type = 'text/javascript';
-      script.src = libraryName;
-      document.getElementsByTagName('head')[0].appendChild(script);
-    }
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.src = libraryName;
+    document.getElementsByTagName('head')[0].appendChild(script);
   },
   REQUIRED_PROTOTYPE: '1.6.0.3',
   load: function() {


### PR DESCRIPTION
Chrome and other browsers get tetchy about using document.write. The DOM method code was already there in the fallback, ironically.